### PR TITLE
TFC-87 - Added negative scenarios with invalid data

### DIFF
--- a/src/test/scala/uk/gov/hmrc/test/api/service/AuthService.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/service/AuthService.scala
@@ -57,6 +57,22 @@ class AuthService(filename: Any) extends HttpClient {
        |    ]
        |}
     """.stripMargin
+  def linkPayload(
+    correlationId: String,
+    eppUniqueCusId: String,
+    eppRegReff: String,
+    outboundChildPayReff: String,
+    childDOB: String
+  ): String =
+    s"""
+       | {
+       | "correlationId":"$correlationId",
+       | "epp_unique_customer_id":"$eppUniqueCusId",
+       | "epp_reg_reference":"$eppRegReff",
+       | "outbound_child_payment_ref":"$outboundChildPayReff",
+       | "child_date_of_birth":"$childDOB"
+       | }
+    """.stripMargin
 
   def postLogin(identifier: String): StandaloneWSRequest#Self#Response = {
     val url = s"$host" + TestConfiguration.getConfigValue("auth-login-stub_uri")

--- a/src/test/scala/uk/gov/hmrc/test/api/specs/CommonSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/CommonSpec.scala
@@ -22,9 +22,11 @@ import io.restassured.http.ContentType
 import io.restassured.response.Response
 import io.restassured.specification.RequestSpecification
 import uk.gov.hmrc.test.api.client.{HttpClient, RestAssured}
+import uk.gov.hmrc.test.api.service.AuthService
 
 trait CommonSpec extends BaseSpec with HttpClient with RestAssured {
   val requestSpecification: RequestSpecification = getRequestSpec
+  val payload: AuthService                       = new AuthService
 
   def givenGetToken(nino: String): String = {
     Given(s"I generate token for NINO:" + nino)
@@ -46,25 +48,33 @@ trait CommonSpec extends BaseSpec with HttpClient with RestAssured {
 
     assert(response.body().prettyPrint() == responseMessage, "Response message not as expected")
   }
-  def getRequestSpec: RequestSpecification                                           = {
+
+  def getRequestSpec: RequestSpecification = {
     val requestSpec = given()
       .config(config().headerConfig(headerConfig().overwriteHeadersWithName("Authorization", "Content-Type")))
       .contentType(ContentType.XML)
       .baseUri(url)
     requestSpec
   }
-  def tfcLink(token: String): Response                                               =
+
+  def tfcLink(
+    token: String,
+    correlationId: String,
+    eppUniqueCusId: String,
+    eppRegReff: String,
+    outboundChildPayReff: String,
+    childDOB: String
+  ): Response =
     requestSpecification
       .header("Authorization", token)
       .header("Content-Type", "application/json")
       .header("Accept", "application/vnd.hmrc.1.0+json")
       .when()
-      .body(
-        "{\"correlationId\":\"5c5ef9c2-72e8-4d4f-901e-9fec3db8c64b\", \"epp_unique_customer_id\":\"EPP-ID\", \"epp_reg_reference\":\"EPP-Req-Ref\", \"outbound_child_payment_ref\":\"Out-Bound-Child-Ref\", \"child_date_of_birth\":\"01-02-2023\"}"
-      )
+      .body(payload.linkPayload(correlationId, eppUniqueCusId, eppRegReff, outboundChildPayReff, childDOB))
       .post(url + s"/link")
       .andReturn()
-  def tfcBalance(token: String): Response                                            =
+
+  def tfcBalance(token: String): Response =
     requestSpecification
       .header("Authorization", token)
       .header("Accept", "application/vnd.hmrc.1.0+json")
@@ -73,4 +83,13 @@ trait CommonSpec extends BaseSpec with HttpClient with RestAssured {
       .post(url + s"/balance")
       .andReturn()
 
+  def thenValidateResponseBody(
+    response: Response,
+    name: String
+  ): String = {
+    val res = response.body().prettyPrint()
+    println("Body is" + res)
+    res
+
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/test/api/specs/CommonSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/CommonSpec.scala
@@ -82,14 +82,4 @@ trait CommonSpec extends BaseSpec with HttpClient with RestAssured {
       .body("")
       .post(url + s"/balance")
       .andReturn()
-
-  def thenValidateResponseBody(
-    response: Response,
-    name: String
-  ): String = {
-    val res = response.body().prettyPrint()
-    println("Body is" + res)
-    res
-
-  }
 }

--- a/src/test/scala/uk/gov/hmrc/test/api/specs/TfcpEndpoints.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/TfcpEndpoints.scala
@@ -20,20 +20,48 @@ import uk.gov.hmrc.test.api.client.HttpClient
 
 class TfcpEndpoints extends BaseSpec with CommonSpec with HttpClient {
 
-  Feature("TFCP APIs") {
+  Feature("TFCP Link APIs") {
+    val consignorToken       = givenGetToken("AB123456C")
+    val correlationId        = "5c5ef9c2-72e8-4d4f-901e-9fec3db8c64b"
+    val eppUniqueCusId       = "12345678910"
+    val eppRegReff           = "EPPRegReffEPPReg"
+    val outboundChildPayReff = "AAAA00000TFC"
+    val childDOB             = "2018-05-23"
 
-    Scenario(s"Connect to TFC api link") {
-
-      val consignorToken = givenGetToken("AB123456C")
-      val response       = tfcLink(consignorToken)
+    Scenario(s"Connect to TFCP api link with valid payload") {
+      val response = tfcLink(consignorToken, correlationId, eppUniqueCusId, eppRegReff, outboundChildPayReff, childDOB)
+      println("Response is --" + response)
       thenValidateResponseCode(response, 200)
-
     }
-
-    Scenario("Connect to TFC api Balance") {
-      val consignorToken = givenGetToken("AB123456D")
-      val response       = tfcBalance(consignorToken)
-      thenValidateResponseCode(response, 200)
+    Scenario(s"Connect to TFCP API link with a payload with an invalid correlation id") {
+      val response =
+        tfcLink(consignorToken, "correlationId", eppUniqueCusId, eppRegReff, outboundChildPayReff, childDOB)
+      println("Response is --" + response)
+      thenValidateResponseCode(response, 400)
+    }
+    Scenario(s"Connect to TFCP API link with a payload with an invalid EPP unique customer ID") {
+      val response =
+        tfcLink(consignorToken, correlationId, "eppUniqueCusId", eppRegReff, outboundChildPayReff, childDOB)
+      println("Response is --" + response)
+      thenValidateResponseCode(response, 400)
+    }
+    Scenario(s"Connect to TFCP API link with a payload with an invalid EPP registration reference") {
+      val response =
+        tfcLink(consignorToken, correlationId, eppUniqueCusId, "eppRegReff", outboundChildPayReff, childDOB)
+      println("Response is --" + response)
+      thenValidateResponseCode(response, 400)
+    }
+    Scenario(s"Connect to TFCP API link with a payload with an invalid Outbound child payment reference number") {
+      val response =
+        tfcLink(consignorToken, correlationId, eppUniqueCusId, eppRegReff, "outboundChildPayReff", childDOB)
+      println("Response is --" + response)
+      thenValidateResponseCode(response, 400)
+    }
+    Scenario(s"Connect to TFCP API link with a payload with an invalid child date of birth") {
+      val response =
+        tfcLink(consignorToken, correlationId, eppUniqueCusId, eppRegReff, outboundChildPayReff, "childDOB")
+      println("Response is --" + response)
+      thenValidateResponseCode(response, 400)
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/test/api/specs/TfcpEndpoints.scala
+++ b/src/test/scala/uk/gov/hmrc/test/api/specs/TfcpEndpoints.scala
@@ -30,37 +30,31 @@ class TfcpEndpoints extends BaseSpec with CommonSpec with HttpClient {
 
     Scenario(s"Connect to TFCP api link with valid payload") {
       val response = tfcLink(consignorToken, correlationId, eppUniqueCusId, eppRegReff, outboundChildPayReff, childDOB)
-      println("Response is --" + response)
       thenValidateResponseCode(response, 200)
     }
     Scenario(s"Connect to TFCP API link with a payload with an invalid correlation id") {
       val response =
         tfcLink(consignorToken, "correlationId", eppUniqueCusId, eppRegReff, outboundChildPayReff, childDOB)
-      println("Response is --" + response)
       thenValidateResponseCode(response, 400)
     }
     Scenario(s"Connect to TFCP API link with a payload with an invalid EPP unique customer ID") {
       val response =
         tfcLink(consignorToken, correlationId, "eppUniqueCusId", eppRegReff, outboundChildPayReff, childDOB)
-      println("Response is --" + response)
       thenValidateResponseCode(response, 400)
     }
     Scenario(s"Connect to TFCP API link with a payload with an invalid EPP registration reference") {
       val response =
         tfcLink(consignorToken, correlationId, eppUniqueCusId, "eppRegReff", outboundChildPayReff, childDOB)
-      println("Response is --" + response)
       thenValidateResponseCode(response, 400)
     }
     Scenario(s"Connect to TFCP API link with a payload with an invalid Outbound child payment reference number") {
       val response =
         tfcLink(consignorToken, correlationId, eppUniqueCusId, eppRegReff, "outboundChildPayReff", childDOB)
-      println("Response is --" + response)
       thenValidateResponseCode(response, 400)
     }
     Scenario(s"Connect to TFCP API link with a payload with an invalid child date of birth") {
       val response =
         tfcLink(consignorToken, correlationId, eppUniqueCusId, eppRegReff, outboundChildPayReff, "childDOB")
-      println("Response is --" + response)
       thenValidateResponseCode(response, 400)
     }
   }


### PR DESCRIPTION
Added below negative scenarios:
 Connect to the TFCP API link with a payload containing an invalid correlation_id
 Connect to the TFCP API link with a payload containing an invalid epp_unique_customer_id
 Connect to the TFCP API link with a payload containing an invalid epp_reg_reference
 Connect to the TFCP API link with a payload containing an invalid outbound_child_payment_ref
 Connect to the TFCP API link with a payload containing an invalid child_date_of_birth